### PR TITLE
Add support to add systemInstruction and update API to V1Beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ _This library is not developed or endorsed by Google._
 First step is to install the Gemini API PHP client with Composer.
 
 ```shell
-composer require gemini-api-php/client
+composer require alexandrevega/gemini-api-client
 ```
 
 Gemini API PHP client does not come with an HTTP client.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 <p align="center">
-    <img src="https://raw.githubusercontent.com/gemini-api-php/client/main/assets/example.png" width="800" alt="Gemini API PHP Client - Example">
+    <img src="https://raw.githubusercontent.com/alexandrevega/gemini-api-client/main/assets/example.png" width="800" alt="Gemini API PHP Client - Example">
 </p>
 <p align="center">
-    <a href="https://packagist.org/packages/gemini-api-php/client"><img alt="Total Downloads" src="https://img.shields.io/packagist/dt/gemini-api-php/client"></a>
-    <a href="https://packagist.org/packages/gemini-api-php/client"><img alt="Latest Version" src="https://img.shields.io/packagist/v/gemini-api-php/client"></a>
-    <a href="https://packagist.org/packages/gemini-api-php/client"><img alt="License" src="https://img.shields.io/github/license/gemini-api-php/client"></a>
+    <a href="https://packagist.org/packages/galexandrevega/gemini-api-client"><img alt="Total Downloads" src="https://img.shields.io/packagist/dt/alexandrevega/gemini-api-client"></a>
+    <a href="https://packagist.org/packages/alexandrevega/gemini-api-client"><img alt="Latest Version" src="https://img.shields.io/packagist/v/alexandrevega/gemini-api-client"></a>
+    <a href="https://packagist.org/packages/alexandrevega/gemini-api-client"><img alt="License" src="https://img.shields.io/github/license/alexandrevega/gemini-api-client"></a>
 </p>
 
 # Gemini API PHP Client
 
-This library is a fork of [gemini-api-php/client](https://github.com/mini-api-php/client) adding system instructions and updating api to v1beta.
+This library is a fork of [gemini-api-php/client](https://github.com/gemini-api-php/client) adding system instructions and updating api to v1beta.
 
 Gemini API PHP Client allows you to use the Google's generative AI models, like Gemini Pro and Gemini Pro Vision.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Gemini API PHP Client allows you to use the Google's generative AI models, like 
 _This library is not developed or endorsed by Google._
 
 - Erdem Köse - **[github.com/erdemkose](https://github.com/erdemkose)**
+- Alexandre Vega - **[github.com/alexandrevega](https://github.com/alexandrevega)**
 
 ## Table of Contents
 - [Installation](#installation)
@@ -24,6 +25,7 @@ _This library is not developed or endorsed by Google._
   - [Chat Session with history](#chat-session-with-history)
   - [Streaming responses](#streaming-responses)
   - [Streaming Chat Session](#streaming-chat-session)
+  - [System Instructions](#system-instructions)
   - [Tokens counting](#tokens-counting)
   - [Listing models](#listing-models)
   - [Advanced Usages](#advanced-usages)
@@ -256,6 +258,58 @@ Response #1
 
 This code will print "Hello World!" to the standard output.
 ```
+
+### System Instruction
+You can add [System Instructions](https://ai.google.dev/gemini-api/docs/system-instructions?hl=en&lang=web) to steer the behaviour of Gemini.
+
+```php
+use GeminiAPI\Client;
+use GeminiAPI\Enums\Role;
+use GeminiAPI\Resources\Content;
+use GeminiAPI\Resources\Parts\TextPart;
+
+$history = [
+    Content::text('Hello World in PHP', Role::User),
+    Content::text(
+        <<<TEXT
+        <?php
+        echo "Hello World!";
+        ?>
+        
+        This code will print "Hello World!" to the standard output.
+        TEXT,
+        Role::Model,
+    ),
+];
+
+$client = new Client('GEMINI_API_KEY');
+$chat = $client->geminiPro()
+    ->withSystemInstruction("You're an expert developer")
+    ->startChat()
+    ->withHistory($history);
+
+$response = $chat->sendMessage(new TextPart('in Go'));
+print $response->text();
+```
+
+```text
+Response #0
+package main
+
+import "fmt"
+
+func main() {
+
+Response #1
+    fmt.Println("Hello World!")
+}
+
+This code will print "Hello World!" to the standard output.
+```
+
+
+
+
 
 ### Embed Content
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 # Gemini API PHP Client
 
+This library is a fork of [gemini-api-php/client](https://github.com/mini-api-php/client) adding system instructions and updating api to v1beta.
+
 Gemini API PHP Client allows you to use the Google's generative AI models, like Gemini Pro and Gemini Pro Vision.
 
 _This library is not developed or endorsed by Google._
@@ -25,7 +27,7 @@ _This library is not developed or endorsed by Google._
   - [Chat Session with history](#chat-session-with-history)
   - [Streaming responses](#streaming-responses)
   - [Streaming Chat Session](#streaming-chat-session)
-  - [System Instructions](#system-instructions)
+  - [System Instruction](#system-instruction)
   - [Tokens counting](#tokens-counting)
   - [Listing models](#listing-models)
   - [Advanced Usages](#advanced-usages)

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "gemini-api-php/client",
+  "name": "alexandrevega/gemini-api-client",
   "description": "API client for Google's Gemini API",
   "keywords": [
     "php",
@@ -17,6 +17,10 @@
     {
       "name": "Erdem Köse",
       "email": "erdemkose@gmail.com"
+    },
+    {
+      "name": "Carlos Ramos",
+      "email": "contact@cramos.dev"
     }
   ],
   "require": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -163,7 +163,7 @@ class Client implements GeminiClientInterface
             }
         }
 
-        curl_setopt($ch, CURLOPT_URL, "{$this->baseUrl}/v1/{$request->getOperation()}");
+        curl_setopt($ch, CURLOPT_URL, "{$this->baseUrl}/v1beta/{$request->getOperation()}");
         curl_setopt($ch, CURLOPT_POST, true);
         curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($request));
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headerLines);
@@ -250,7 +250,7 @@ class Client implements GeminiClientInterface
             throw new RuntimeException('Missing client or factory for Gemini API operation');
         }
 
-        $uri = "{$this->baseUrl}/v1/{$request->getOperation()}";
+        $uri = "{$this->baseUrl}/v1beta/{$request->getOperation()}";
         $httpRequest = $this->requestFactory
             ->createRequest($request->getHttpMethod(), $uri);
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -103,7 +103,7 @@ class Client implements GeminiClientInterface
         );
     }
 
-    /**
+    /**x
      * @throws ClientExceptionInterface
      */
     public function generateContent(GenerateContentRequest $request): GenerateContentResponse

--- a/src/GenerativeModel.php
+++ b/src/GenerativeModel.php
@@ -100,6 +100,7 @@ class GenerativeModel
             $contents,
             $this->safetySettings,
             $this->generationConfig,
+            $this->systemInstruction
         );
 
         $this->client->generateContentStream($request, $callback, $ch);

--- a/src/GenerativeModel.php
+++ b/src/GenerativeModel.php
@@ -144,7 +144,7 @@ class GenerativeModel
     {
 
         $clone = clone $this;
-        $this->systemInstruction = $instruction;
+        $clone->systemInstruction = $instruction;
 
         return $clone;
     }

--- a/src/GenerativeModel.php
+++ b/src/GenerativeModel.php
@@ -11,6 +11,7 @@ use GeminiAPI\Enums\Role;
 use GeminiAPI\Requests\CountTokensRequest;
 use GeminiAPI\Requests\GenerateContentRequest;
 use GeminiAPI\Requests\GenerateContentStreamRequest;
+use GeminiAPI\Resources\Parts\TextPart;
 use GeminiAPI\Responses\CountTokensResponse;
 use GeminiAPI\Responses\GenerateContentResponse;
 use GeminiAPI\Resources\Content;
@@ -25,7 +26,7 @@ class GenerativeModel
     /** @var SafetySetting[] */
     private array $safetySettings = [];
 
-    private ?string $systemInstruction = null;
+    private ?array $systemInstruction = null;
 
     private ?GenerationConfig $generationConfig = null;
 
@@ -145,7 +146,7 @@ class GenerativeModel
     {
 
         $clone = clone $this;
-        $clone->systemInstruction = $instruction;
+        $clone->systemInstruction['parts'] = [new TextPart($instruction)];
 
         return $clone;
     }

--- a/src/GenerativeModel.php
+++ b/src/GenerativeModel.php
@@ -25,6 +25,8 @@ class GenerativeModel
     /** @var SafetySetting[] */
     private array $safetySettings = [];
 
+    private ?string $systemInstruction = null;
+
     private ?GenerationConfig $generationConfig = null;
 
     public function __construct(
@@ -56,6 +58,7 @@ class GenerativeModel
             $contents,
             $this->safetySettings,
             $this->generationConfig,
+            $this->systemInstruction
         );
 
         return $this->client->generateContent($request);
@@ -133,6 +136,15 @@ class GenerativeModel
     {
         $clone = clone $this;
         $clone->generationConfig = $generationConfig;
+
+        return $clone;
+    }
+
+    public function withSystemInstruction(?string $instruction = null): self
+    {
+
+        $clone = clone $this;
+        $this->systemInstruction = $instruction;
 
         return $clone;
     }

--- a/src/Requests/GenerateContentRequest.php
+++ b/src/Requests/GenerateContentRequest.php
@@ -22,12 +22,14 @@ class GenerateContentRequest implements JsonSerializable, RequestInterface
      * @param Content[] $contents
      * @param SafetySetting[] $safetySettings
      * @param GenerationConfig|null $generationConfig
+     * @param string|null $systemInstruction
      */
     public function __construct(
         public readonly ModelName $modelName,
         public readonly array $contents,
         public readonly array $safetySettings = [],
         public readonly ?GenerationConfig $generationConfig = null,
+        public ?string $systemInstruction = null
     ) {
         $this->ensureArrayOfType($this->contents, Content::class);
         $this->ensureArrayOfType($this->safetySettings, SafetySetting::class);
@@ -69,6 +71,10 @@ class GenerateContentRequest implements JsonSerializable, RequestInterface
 
         if ($this->generationConfig) {
             $arr['generationConfig'] = $this->generationConfig;
+        }
+
+        if ($this->systemInstruction) {
+            $arr['system_instruction'] = $this->systemInstruction;
         }
 
         return $arr;

--- a/src/Requests/GenerateContentRequest.php
+++ b/src/Requests/GenerateContentRequest.php
@@ -22,14 +22,14 @@ class GenerateContentRequest implements JsonSerializable, RequestInterface
      * @param Content[] $contents
      * @param SafetySetting[] $safetySettings
      * @param GenerationConfig|null $generationConfig
-     * @param string|null $systemInstruction
+     * @param string|null $systemInstructions
      */
     public function __construct(
         public readonly ModelName $modelName,
         public readonly array $contents,
         public readonly array $safetySettings = [],
         public readonly ?GenerationConfig $generationConfig = null,
-        public ?string $systemInstruction = null
+        public ?array $systemInstructions = null
     ) {
         $this->ensureArrayOfType($this->contents, Content::class);
         $this->ensureArrayOfType($this->safetySettings, SafetySetting::class);
@@ -73,8 +73,8 @@ class GenerateContentRequest implements JsonSerializable, RequestInterface
             $arr['generationConfig'] = $this->generationConfig;
         }
 
-        if ($this->systemInstruction) {
-            $arr['system_instruction'] = $this->systemInstruction;
+        if ($this->systemInstructions) {
+            $arr['systemInstruction'] = $this->systemInstructions;
         }
 
         return $arr;

--- a/src/Requests/GenerateContentStreamRequest.php
+++ b/src/Requests/GenerateContentStreamRequest.php
@@ -22,12 +22,15 @@ class GenerateContentStreamRequest implements JsonSerializable, RequestInterface
      * @param Content[] $contents
      * @param SafetySetting[] $safetySettings
      * @param GenerationConfig|null $generationConfig
+     * @param string|null $systemInstruction
      */
     public function __construct(
         public readonly ModelName $modelName,
         public readonly array $contents,
         public readonly array $safetySettings = [],
         public readonly ?GenerationConfig $generationConfig = null,
+        public readonly ?string $systemInstruction = null
+
     ) {
         $this->ensureArrayOfType($this->contents, Content::class);
         $this->ensureArrayOfType($this->safetySettings, SafetySetting::class);
@@ -69,6 +72,10 @@ class GenerateContentStreamRequest implements JsonSerializable, RequestInterface
 
         if ($this->generationConfig) {
             $arr['generationConfig'] = $this->generationConfig;
+        }
+
+        if ($this->systemInstruction) {
+            $arr['system_instruction'] = $this->systemInstruction;
         }
 
         return $arr;

--- a/src/Requests/GenerateContentStreamRequest.php
+++ b/src/Requests/GenerateContentStreamRequest.php
@@ -29,7 +29,7 @@ class GenerateContentStreamRequest implements JsonSerializable, RequestInterface
         public readonly array $contents,
         public readonly array $safetySettings = [],
         public readonly ?GenerationConfig $generationConfig = null,
-        public readonly ?string $systemInstruction = null
+        public ?string $systemInstruction = null
 
     ) {
         $this->ensureArrayOfType($this->contents, Content::class);

--- a/src/Requests/GenerateContentStreamRequest.php
+++ b/src/Requests/GenerateContentStreamRequest.php
@@ -29,7 +29,7 @@ class GenerateContentStreamRequest implements JsonSerializable, RequestInterface
         public readonly array $contents,
         public readonly array $safetySettings = [],
         public readonly ?GenerationConfig $generationConfig = null,
-        public ?string $systemInstruction = null
+        public ?array $systemInstructions = null
 
     ) {
         $this->ensureArrayOfType($this->contents, Content::class);
@@ -74,8 +74,8 @@ class GenerateContentStreamRequest implements JsonSerializable, RequestInterface
             $arr['generationConfig'] = $this->generationConfig;
         }
 
-        if ($this->systemInstruction) {
-            $arr['system_instruction'] = $this->systemInstruction;
+        if ($this->systemInstructions) {
+            $arr['systemInstruction'] = $this->systemInstructions;
         }
 
         return $arr;

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -78,7 +78,7 @@ class ClientTest extends TestCase
     {
         $httpRequest = new Request(
             'POST',
-            'https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent',
+            'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent',
         );
         $httpResponse = new Response(
             body: <<<BODY
@@ -117,7 +117,7 @@ class ClientTest extends TestCase
         $requestFactory = $this->createMock(RequestFactoryInterface::class);
         $requestFactory->expects(self::once())
             ->method('createRequest')
-            ->with('POST', 'https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent')
+            ->with('POST', 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent')
             ->willReturn($httpRequest);
 
         $httpRequest = $httpRequest
@@ -155,7 +155,7 @@ class ClientTest extends TestCase
     {
         $httpRequest = new Request(
             'POST',
-            'https://generativelanguage.googleapis.com/v1/models/embedding-001:embedContent',
+            'https://generativelanguage.googleapis.com/v1beta/models/embedding-001:embedContent',
         );
         $httpResponse = new Response(
             body: <<<BODY
@@ -172,7 +172,7 @@ class ClientTest extends TestCase
         $requestFactory = $this->createMock(RequestFactoryInterface::class);
         $requestFactory->expects(self::once())
             ->method('createRequest')
-            ->with('POST', 'https://generativelanguage.googleapis.com/v1/models/embedding-001:embedContent')
+            ->with('POST', 'https://generativelanguage.googleapis.com/v1beta/models/embedding-001:embedContent')
             ->willReturn($httpRequest);
 
         $httpRequest = $httpRequest
@@ -210,7 +210,7 @@ class ClientTest extends TestCase
     {
         $httpRequest = new Request(
             'POST',
-            'https://generativelanguage.googleapis.com/v1/models/gemini-pro:countTokens',
+            'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:countTokens',
         );
         $httpResponse = new Response(
             body: <<<BODY
@@ -222,7 +222,7 @@ class ClientTest extends TestCase
         $requestFactory = $this->createMock(RequestFactoryInterface::class);
         $requestFactory->expects(self::once())
             ->method('createRequest')
-            ->with('POST', 'https://generativelanguage.googleapis.com/v1/models/gemini-pro:countTokens')
+            ->with('POST', 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:countTokens')
             ->willReturn($httpRequest);
 
         $httpRequest = $httpRequest
@@ -260,7 +260,7 @@ class ClientTest extends TestCase
     {
         $httpRequest = new Request(
             'GET',
-            'https://generativelanguage.googleapis.com/v1/models',
+            'https://generativelanguage.googleapis.com/v1beta/models',
         );
         $httpResponse = new Response(
             body: <<<BODY
@@ -303,7 +303,7 @@ class ClientTest extends TestCase
         $requestFactory = $this->createMock(RequestFactoryInterface::class);
         $requestFactory->expects(self::once())
             ->method('createRequest')
-            ->with('GET', 'https://generativelanguage.googleapis.com/v1/models')
+            ->with('GET', 'https://generativelanguage.googleapis.com/v1beta/models')
             ->willReturn($httpRequest);
 
         $httpRequest = $httpRequest


### PR DESCRIPTION
Added support for system instruction (using method withSystemInstruction(string $systemInstruction))
Updated url from ´v1´to ´v1beta´ in order to support this feature.

It would be easily adaptable to support multiple system instructions extending the current methods.

This should resolve #46 