### PR TITLE
Enhance Token Counting to Include Chat History and System Instructions

### DIFF
--- a/src/ChatSession.php
+++ b/src/ChatSession.php
@@ -106,7 +106,7 @@ class ChatSession
     public function countTokens(PartInterface ...$parts): CountTokensResponse
     {
         // Concatenate the parts of the history if it exists
-        if ($this->history) {
+        if (!empty($this->history)) {
             foreach ($this->history as $content) {
                 $parts = array_merge($content->parts, $parts);
             }

--- a/src/ChatSession.php
+++ b/src/ChatSession.php
@@ -7,6 +7,7 @@ namespace GeminiAPI;
 use GeminiAPI\Enums\Role;
 use GeminiAPI\Resources\Content;
 use GeminiAPI\Resources\Parts\PartInterface;
+use GeminiAPI\Responses\CountTokensResponse;
 use GeminiAPI\Responses\GenerateContentResponse;
 use GeminiAPI\Traits\ArrayTypeValidator;
 use InvalidArgumentException;
@@ -97,5 +98,20 @@ class ChatSession
         $clone->history = $history;
 
         return $clone;
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     */
+    public function countTokens(PartInterface ...$parts): CountTokensResponse
+    {
+        // Concatenate the parts of the history if it exists
+        if ($this->history) {
+            foreach ($this->history as $content) {
+                $parts = array_merge($content->parts, $parts);
+            }
+        }
+
+        return $this->model->countTokens(...$parts);
     }
 }

--- a/src/GenerativeModel.php
+++ b/src/GenerativeModel.php
@@ -115,12 +115,17 @@ class GenerativeModel
      */
     public function countTokens(PartInterface ...$parts): CountTokensResponse
     {
-        $content = new Content($parts, Role::User);
+        $temporaryContent = new Content($parts, Role::User);
+
+        // Add system instruction if it exists
+        if ($this->systemInstruction !== null) {
+            $temporaryContent = $temporaryContent->addParts(...$this->systemInstruction->parts);
+        }
+
         $request = new CountTokensRequest(
             $this->modelName,
-            [$content],
+            [$temporaryContent]
         );
-
         return $this->client->countTokens($request);
     }
 

--- a/src/Resources/Content.php
+++ b/src/Resources/Content.php
@@ -48,6 +48,15 @@ class Content
         return $this;
     }
 
+    public function addParts(PartInterface ...$parts): self
+    {
+        $this->ensureArrayOfType($parts, PartInterface::class);
+
+        $this->parts = array_merge($this->parts, $parts);
+
+        return $this;
+    }
+
     public static function text(
         string $text,
         Role $role = Role::User,

--- a/src/Resources/Content.php
+++ b/src/Resources/Content.php
@@ -50,9 +50,11 @@ class Content
 
     public function addParts(PartInterface ...$parts): self
     {
-        $this->ensureArrayOfType($parts, PartInterface::class);
+        /** @var array<int, PartInterface> $typedParts */
+        $typedParts = $parts;
 
-        $this->parts = array_merge($this->parts, $parts);
+        $this->ensureArrayOfType($typedParts, PartInterface::class);
+        $this->parts = array_merge($this->parts, $typedParts);
 
         return $this;
     }


### PR DESCRIPTION
## Overview
This pull request introduces enhancements to the token counting functionalities within our chat models. The updates ensure that token counting reflects the entire context of a chat session, including chat history and system instructions, aligning our implementation with the official Gemini API guidelines.

## Changes
1. **Chat Session Token Counting**: Added a new function in the `ChatSession` class to calculate the total token count that includes the history of the chat session. This modification allows us to capture the multi-turn nature of conversations, as described in the Gemini API documentation:
   [Multi-turn Tokens Documentation](https://ai.google.dev/gemini-api/docs/tokens?lang=python#multi-turn-tokens).

2. **System Instructions Integration**: Updated the `GenerativeModel` class's token counting method to factor in system instructions. This ensures that our token counting is comprehensive and covers all elements that could potentially consume tokens as outlined here:
   [System Instructions and Tools Documentation](https://ai.google.dev/gemini-api/docs/tokens?lang=python#system-instructions-and-tools).

## Motivation
The necessity for these updates was evident from the discussions in ticket #58, where it was highlighted that the current token counting mechanism did not account for the comprehensive context used by the Gemini API, leading to discrepancies in token usage calculations.

These enhancements ensure that our models are fully compliant with the guidelines and functionalities supported by the Gemini API, providing a more accurate and reliable count of token usage across different scenarios.

I look forward to your feedback on these enhancements.
