### PR TITLE
Add responseMimeType and responseSchema to GenerationConfig

### DIFF
--- a/src/Enums/MimeType.php
+++ b/src/Enums/MimeType.php
@@ -9,6 +9,7 @@ enum MimeType: string
     case FILE_PDF = 'application/pdf'; // Will not rename to APPLICATION_PDF to keep the backwards compatibility
     case APPLICATION_JAVASCRIPT = 'application/x-javascript';
     case APPLICATION_PYTHON = 'application/x-python';
+    case APPLICATION_JSON = 'application/json';
 
     case TEXT_PLAIN = 'text/plain';
     case TEXT_HTML = 'text/html';

--- a/src/GenerationConfig.php
+++ b/src/GenerationConfig.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GeminiAPI;
 
+use GeminiAPI\Enums\MimeType;
 use GeminiAPI\Traits\ArrayTypeValidator;
 use JsonSerializable;
 use UnexpectedValueException;
@@ -19,6 +20,7 @@ class GenerationConfig implements JsonSerializable
      *     temperature?: float,
      *     topP?: float,
      *     topK?: int,
+     *     responseMimeType?: string
      * }
      */
     private array $config;
@@ -97,6 +99,14 @@ class GenerationConfig implements JsonSerializable
         return $clone;
     }
 
+    public function withResponseMimeType(MimeType $mimeType)
+    {
+        $clone = clone $this;
+        $clone->config['responseMimeType'] = $mimeType->value;
+
+        return $clone;
+    }
+
     /**
      * @return array{
      *      candidateCount?: int,
@@ -105,6 +115,7 @@ class GenerationConfig implements JsonSerializable
      *      temperature?: float,
      *      topP?: float,
      *      topK?: int,
+     *      responseMimeType?: string
      *  }
      */
     public function jsonSerialize(): array

--- a/src/GenerationConfig.php
+++ b/src/GenerationConfig.php
@@ -20,7 +20,8 @@ class GenerationConfig implements JsonSerializable
      *     temperature?: float,
      *     topP?: float,
      *     topK?: int,
-     *     responseMimeType?: string
+     *     responseMimeType?: string,
+     *     responseSchema?: array
      * }
      */
     private array $config;
@@ -107,6 +108,14 @@ class GenerationConfig implements JsonSerializable
         return $clone;
     }
 
+    public function withResponseSchema(array $schema)
+    {
+        $clone = clone $this;
+        $clone->config['responseSchema'] = $schema;
+
+        return $clone;
+    }
+
     /**
      * @return array{
      *      candidateCount?: int,
@@ -115,7 +124,8 @@ class GenerationConfig implements JsonSerializable
      *      temperature?: float,
      *      topP?: float,
      *      topK?: int,
-     *      responseMimeType?: string
+     *      responseMimeType?: string,
+     *      responseSchema?: array
      *  }
      */
     public function jsonSerialize(): array


### PR DESCRIPTION
This allows structured output usage.

```php
$client = new Client($key);
$clent = $client->withV1BetaVersion()->generativeModel('gemini-2.0-flash');

$config = (new GenerationConfig())
              ->withResponseMimeType(MimeType::APPLICATION_JSON)
              ->withResponseSchema([
                'type' => 'string',
                'enum' => [
                    'hotdog',
                    'fries',
                    'coke'
                ]
              ]);
        

$client->withGenerationConfig($config)->generateContent('....');
```


