### PR TITLE
feat: add new MIME types supported by latest models

### DIFF
--- a/src/Enums/MimeType.php
+++ b/src/Enums/MimeType.php
@@ -6,21 +6,52 @@ namespace GeminiAPI\Enums;
 
 enum MimeType: string
 {
+    // Documents
     case FILE_PDF = 'application/pdf'; // Will not rename to APPLICATION_PDF to keep the backwards compatibility
     case APPLICATION_JAVASCRIPT = 'application/x-javascript';
     case APPLICATION_PYTHON = 'application/x-python';
 
+    // Sheets
+    case TEXT_CSV = 'text/csv';
+
+    // Text and Code
     case TEXT_PLAIN = 'text/plain';
     case TEXT_HTML = 'text/html';
     case TEXT_CSS = 'text/css';
     case TEXT_MARKDOWN = 'text/md';
-    case TEXT_CSV = 'text/csv';
     case TEXT_XML = 'text/xml';
     case TEXT_RTF = 'text/rtf';
+    case TEXT_X_C = 'text/x-c';
+    case TEXT_X_CPP = 'text/x-c++';
+    case TEXT_X_JAVA = 'text/x-java-source';
 
+    // Images
     case IMAGE_PNG = 'image/png';
     case IMAGE_JPEG = 'image/jpeg';
     case IMAGE_HEIC = 'image/heic';
     case IMAGE_HEIF = 'image/heif';
     case IMAGE_WEBP = 'image/webp';
+
+    // Videos
+    case VIDEO_MP4 = 'video/mp4';
+    case VIDEO_WEBM = 'video/webm';
+    case VIDEO_MPEG = 'video/mpeg';
+    case VIDEO_MPG = 'video/mpg';
+    case VIDEO_WMV = 'video/wmv';
+    case VIDEO_3GPP = 'video/3gpp';
+    case VIDEO_QUICKTIME = 'video/quicktime';
+    case VIDEO_X_FLV = 'video/x-flv';
+
+    // Audio
+    case AUDIO_MP3 = 'audio/mp3';
+    case AUDIO_MPEG = 'audio/mpeg';
+    case AUDIO_MP4 = 'audio/mp4';
+    case AUDIO_MPGA = 'audio/mpga';
+    case AUDIO_FLAC = 'audio/flac';
+    case AUDIO_OGG = 'audio/ogg';
+    case AUDIO_OPUS = 'audio/opus';
+    case AUDIO_PCM = 'audio/pcm';
+    case AUDIO_WAV = 'audio/wav';
+    case AUDIO_WEBM = 'audio/webm';
+    case AUDIO_MPA = 'audio/m4a';
 }

--- a/src/Enums/ModelName.php
+++ b/src/Enums/ModelName.php
@@ -18,4 +18,18 @@ enum ModelName: string
     case GeminiProVision = 'models/gemini-pro-vision';
     case Embedding = 'models/embedding-001';
     case AQA = 'models/aqa';
+
+    // Latest versions of the models
+    case Gemini15Pro002 = 'models/gemini-1.5-pro-002';
+    case Gemini15Flash002 = 'models/gemini-1.5-flash-002';
+    case Gemini15Flash8B = 'models/gemini-1.5-flash-8b';
+    case Gemini15Flash8BLatest = 'models/gemini-1.5-flash-8b-latest';
+    case Gemini20Flash = 'models/gemini-2.0-flash';
+    case Gemini20FlashLite = 'models/gemini-2.0-flash-lite';
+    case Gemini20FlashLive001 = 'models/gemini-2.0-flash-live-001';
+    case Gemini25ProPreview0325 = 'models/gemini-2.5-pro-preview-03-25';
+    case Gemini25ProExp0325 = 'models/gemini-2.5-pro-exp-03-25';
+    case GeminiEmbeddingExp = 'models/gemini-embedding-exp';
+    case Imagen3 = 'models/imagen-3.0-generate-002';
+    case Veo2 = 'models/veo-2.0-generate-001';
 }

--- a/src/Resources/Parts/FilePart.php
+++ b/src/Resources/Parts/FilePart.php
@@ -11,10 +11,13 @@ use function json_encode;
 
 class FilePart implements PartInterface, JsonSerializable
 {
+    private readonly string $mimeTypeValue;
+    
     public function __construct(
-        public readonly MimeType $mimeType,
+        public readonly MimeType|string $mimeType,
         public readonly string $data,
     ) {
+        $this->mimeTypeValue = $mimeType instanceof MimeType ? $mimeType->value : $mimeType;
     }
 
     /**
@@ -29,7 +32,7 @@ class FilePart implements PartInterface, JsonSerializable
     {
         return [
             'inlineData' => [
-                'mimeType' => $this->mimeType->value,
+                'mimeType' => $this->mimeTypeValue,
                 'data' => $this->data,
             ],
         ];


### PR DESCRIPTION
# New MIME Types Supported

Since the release of Gemini 2.0 Flash, several new MIME types have been supported. However, they were not yet added to the `MimeType` enum. Since building a `FilePart` for a request requires a valid `MimeType` enum instance, I decided to investigate.

After reviewing [the official Gemini model documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-pro), I wrote a test script to try different file types and included all supported types in the enum.

## Notes

Some MIME types like `application/x-javascript` and `application/x-python` were rejected by `gemini-2.0-flash` during testing. However, they have been preserved in the enum to maintain backwards compatibility with existing SDK users.

## Output from my tests
[MIME_Types_Test.csv](https://github.com/user-attachments/files/19726089/MIME_Types_Atualizados_com_Suporte_do_SDK_e_Documenta__o.csv)

