### PR TITLE
Updated supported MIME types and added new FileUriPart.

### DIFF
--- a/src/Enums/MimeType.php
+++ b/src/Enums/MimeType.php
@@ -6,10 +6,12 @@ namespace GeminiAPI\Enums;
 
 enum MimeType: string
 {
+    // Documents
     case FILE_PDF = 'application/pdf'; // Will not rename to APPLICATION_PDF to keep the backwards compatibility
     case APPLICATION_JAVASCRIPT = 'application/x-javascript';
     case APPLICATION_PYTHON = 'application/x-python';
 
+    // Text and Code
     case TEXT_PLAIN = 'text/plain';
     case TEXT_HTML = 'text/html';
     case TEXT_CSS = 'text/css';
@@ -17,10 +19,37 @@ enum MimeType: string
     case TEXT_CSV = 'text/csv';
     case TEXT_XML = 'text/xml';
     case TEXT_RTF = 'text/rtf';
+    case TEXT_X_C = 'text/x-c';
+    case TEXT_X_CPP = 'text/x-c++';
+    case TEXT_X_JAVA = 'text/x-java-source';
 
+    // Images
     case IMAGE_PNG = 'image/png';
     case IMAGE_JPEG = 'image/jpeg';
     case IMAGE_HEIC = 'image/heic';
     case IMAGE_HEIF = 'image/heif';
     case IMAGE_WEBP = 'image/webp';
+
+    // Videos
+    case VIDEO_MP4 = 'video/mp4';
+    case VIDEO_WEBM = 'video/webm';
+    case VIDEO_MPEG = 'video/mpeg';
+    case VIDEO_MPG = 'video/mpg';
+    case VIDEO_WMV = 'video/wmv';
+    case VIDEO_3GPP = 'video/3gpp';
+    case VIDEO_QUICKTIME = 'video/quicktime';
+    case VIDEO_X_FLV = 'video/x-flv';
+
+    // Audio
+    case AUDIO_MP3 = 'audio/mp3';
+    case AUDIO_MPEG = 'audio/mpeg';
+    case AUDIO_MP4 = 'audio/mp4';
+    case AUDIO_MPGA = 'audio/mpga';
+    case AUDIO_FLAC = 'audio/flac';
+    case AUDIO_OGG = 'audio/ogg';
+    case AUDIO_OPUS = 'audio/opus';
+    case AUDIO_PCM = 'audio/pcm';
+    case AUDIO_WAV = 'audio/wav';
+    case AUDIO_WEBM = 'audio/webm';
+    case AUDIO_MPA = 'audio/m4a';
 }

--- a/src/Resources/ModelName.php
+++ b/src/Resources/ModelName.php
@@ -23,11 +23,13 @@ class ModelName
     public const GEMINI_1_5_FLASH_001 = 'gemini-1.5-flash-001';
     public const GEMINI_1_5_FLASH_002 = 'gemini-1.5-flash-002';
     public const GEMINI_1_5_FLASH_LATEST = 'gemini-1.5-flash-latest';
-
+    public const GEMINI_2_0_FLASH = 'gemini-2.0-flash';
+    
     // Optimized for: High volume and lower intelligence tasks
     public const GEMINI_1_5_FLASH_8B = 'gemini-1.5-flash-8b';
     public const GEMINI_1_5_FLASH_8B_001 = 'gemini-1.5-flash-8b-001';
     public const GEMINI_1_5_FLASH_8B_LATEST = 'gemini-1.5-flash-8b-latest';
+    public const GEMINI_2_0_FLASH_LITE = 'gemini-2.0-flash-lite';
 
     // Optimized for: Measuring the relatedness of text strings
     public const TEXT_EMBEDDING_004 = 'text-embedding-004';

--- a/src/Resources/Parts/FileUriPart.php
+++ b/src/Resources/Parts/FileUriPart.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace GeminiAPI\Resources\Parts;
+
+use GeminiAPI\Resources\Parts\PartInterface;
+use GeminiAPI\Enums\MimeType;
+use JsonSerializable;
+
+class FileUriPart implements PartInterface, JsonSerializable
+{
+    public function __construct(
+        public readonly MimeType $mimeType,
+        public readonly string $uri
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     file_data: array{
+     *         mime_type: string,
+     *         file_uri: string,
+     *     },
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'file_data' => [
+                'mime_type' => $this->mimeType->value,
+                'file_uri' => $this->uri
+            ],
+        ];
+    }
+
+    public function __toString(): string
+    {
+        return json_encode($this) ?: '';
+    }
+}

--- a/tests/Unit/Resources/Parts/FileUriPartTest.php
+++ b/tests/Unit/Resources/Parts/FileUriPartTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GeminiAPI\Tests\Unit\Resources\Parts;
+
+use GeminiAPI\Enums\MimeType;
+use GeminiAPI\Resources\Parts\FileUriPart;
+use PHPUnit\Framework\TestCase;
+
+class FileUriPartTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $part = new FileUriPart(MimeType::VIDEO_MP4, '');
+        self::assertInstanceOf(FileUriPart::class, $part);
+    }
+
+    public function testJsonSerialize()
+    {
+        $part = new FileUriPart(MimeType::VIDEO_MP4, 'https://www.youtube.com/watch?v=9hE5-98ZeCg');
+        $expected = [
+            'file_data' => [
+                'mime_type' => 'video/mp4',
+                'file_uri' => 'https://www.youtube.com/watch?v=9hE5-98ZeCg',
+            ],
+        ];
+        self::assertEquals($expected, $part->jsonSerialize());
+    }
+
+    public function test__toString()
+    {
+        $part = new FileUriPart(MimeType::VIDEO_MP4, 'https://www.youtube.com/watch?v=9hE5-98ZeCg');
+        $expected = '{"file_data":{"mime_type":"video\/mp4","file_uri":"https:\/\/www.youtube.com\/watch?v=9hE5-98ZeCg"}}';
+        self::assertEquals($expected, (string) $part);
+    }
+}


### PR DESCRIPTION
Additional MIME types have been added to Gemini and are now supported via a new file_data part, as detailed in the documentation below:

[Using with YouTube videos](https://ai.google.dev/gemini-api/docs/video-understanding)

[Using with other file types](https://ai.google.dev/gemini-api/docs/files)